### PR TITLE
Added support for SSH keys.

### DIFF
--- a/image-build-context/add_public_key.sh
+++ b/image-build-context/add_public_key.sh
@@ -1,0 +1,14 @@
+PUBLIC_KEY=$1
+SCRIPT=$(
+cat <<EOF
+
+%post
+mkdir /root/.ssh/
+echo ${PUBLIC_KEY} > /root/.ssh/authorized_keys
+chmod 0700 /root/.ssh/
+chmod 0600 /root/.ssh/authorized_keys
+%end
+EOF
+)
+echo "${SCRIPT}" >> /usr/local/apache2/htdocs/ubuntu/16.04/ks.cfg
+echo "${SCRIPT}" >> /usr/local/apache2/htdocs/centos/7.6/ks.cfg

--- a/image-build-context/dockerfile
+++ b/image-build-context/dockerfile
@@ -51,6 +51,8 @@ COPY configure-supervisor.sh /configure-supervisor.sh
 RUN chmod 755 /configure-supervisor.sh
 RUN /configure-supervisor.sh
 
+COPY add_public_key.sh /add_public_key.sh
+RUN chmod 755 /add_public_key.sh
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/image-build-context/entrypoint.sh
+++ b/image-build-context/entrypoint.sh
@@ -1,2 +1,9 @@
 #!/bin/bash
+
+if [[ -f /ssh/id_rsa.pub ]]
+then
+    PUBLIC_KEY=$(cat /ssh/id_rsa.pub)
+    /add_public_key.sh "${PUBLIC_KEY}"
+fi
+
 exec supervisord --nodaemon


### PR DESCRIPTION
As of now, the PXE server can take as input an SSH key. This key
gets added to the list of authorized keys of the client machine.